### PR TITLE
Update to use start instead of start_link

### DIFF
--- a/game/dictionary/lib/dictionary/application.ex
+++ b/game/dictionary/lib/dictionary/application.ex
@@ -2,7 +2,7 @@ defmodule Dictionary.Application do
 
   use Application
 
-  def start_link(_type, _args) do
+  def start(_type, _args) do
     Dictionary.WordList.start_link()
   end
 


### PR DESCRIPTION
Couldn't run the example. Was getting the following error:

```
$ iex -S mix
Erlang/OTP 20 [erts-9.1.5] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Compiling 3 files (.ex)
warning: undefined behaviour function start/2 (for behaviour Application)
  lib/dictionary/application.ex:1

Generated dictionary app

=INFO REPORT==== 30-Nov-2017::00:16:34 ===
    application: logger
    exited: stopped
    type: temporary
** (Mix) Could not start application dictionary: exited in: Dictionary.Application.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (UndefinedFunctionError) function Dictionary.Application.start/2 is undefined or private. Did you mean one of:

      * start_link/2

            (dictionary) Dictionary.Application.start(:normal, [])
            (kernel) application_master.erl:273: :application_master.start_it_old/4
```

With the following elixir version:

```
$ elixir -v
Erlang/OTP 20 [erts-9.1.5] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Elixir 1.5.2
```

