### PR TITLE
Allow guessed word to show on game end

### DIFF
--- a/game/text_client/lib/text_client/player.ex
+++ b/game/text_client/lib/text_client/player.ex
@@ -2,11 +2,11 @@ defmodule TextClient.Player do
 
   alias TextClient.{Mover, Prompt, State, Summary}
   
-  def play(%State{tally: %{ game_state: :won, letters: letters }}) do
+  def play(%State{game_service: %{ letters: letters }, tally: %{ game_state: :won }}) do
     end_with_message("You WON!", letters)
   end
   
-  def play(%State{tally: %{ game_state: :lost, letters: letters }}) do
+  def play(%State{game_service: %{ letters: letters }, tally: %{ game_state: :lost }}) do
     end_with_message("Sorry, you lost...", letters)
   end
 


### PR DESCRIPTION
The previous implementation used `letters` from `tally` which is the letters the user *already* guessed, meaning if the user didn't win, the printed word would have contained `_` where missing letters are.

This commit sets `letters` from `game_service` which is the actual word, allowing the word to be shown.